### PR TITLE
Akka persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.sublime-project
+*.sublime-workspace
+snapshots/*
 journal/*
 logs
 project/project


### PR DESCRIPTION
I added some logging to the actor snapshot logic using the messages described in the akka docs. I found that the error preventing us to save the snapshot was a weird serialization error:

```
java.io.NotSerializableException: kaning.actors.ChatServerActor
```

After a bit of struggling to understand why akka was trying to serialize the ChatServerActor I learnt an interesting lesson for the future: if you put a class definition within another class the inner one will somehow retain a link to the containing one. Moving the ChatServerState definition to the companion object fixed everything!

So :cool: 
